### PR TITLE
Redirect turnstyl.ts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-const { Turnstyl } = require('./src/turnstyl.ts');
+const { Turnstyl } = require("./src/turnstyl");
 
 module.exports = {
   Turnstyl,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turnstyl",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Turnstyl is an NPM package built to work with Kafka to allow you to compare the data schema input at the producer level to what arrives into your data warehouse.",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",


### PR DESCRIPTION
### Summary

- referring to turnstyl is generalized

### Changes being made

- Require `turnstyl` instead of `turnstyl.ts` in `index.ts`